### PR TITLE
fix: avoid mis-detecting ~/.openclaw as workspace

### DIFF
--- a/src/services/openclaw.js
+++ b/src/services/openclaw.js
@@ -8,6 +8,27 @@ const { HOME_DIR, APP_DIR } = require('../config');
 
 let workspaceCache = null;
 
+function hasReadableMemoryMarkdown(baseDir) {
+    try {
+        const memoryDir = path.join(baseDir, 'memory');
+        if (!fs.existsSync(memoryDir) || !fs.statSync(memoryDir).isDirectory()) return false;
+
+        const files = fs.readdirSync(memoryDir);
+        return files.some(f => /^\d{4}-\d{2}-\d{2}(?:-.+)?\.md$/.test(f));
+    } catch {
+        return false;
+    }
+}
+
+function isWorkspaceLike(baseDir) {
+    // A real OpenClaw workspace usually has MEMORY.md/AGENTS.md and markdown memories.
+    return (
+        hasReadableMemoryMarkdown(baseDir) ||
+        fs.existsSync(path.join(baseDir, 'MEMORY.md')) ||
+        fs.existsSync(path.join(baseDir, 'AGENTS.md'))
+    );
+}
+
 function findWorkspace() {
     // 1. Explicit env var (Highest priority)
     if (process.env.OPENCLAW_WORKSPACE) return process.env.OPENCLAW_WORKSPACE;
@@ -17,20 +38,22 @@ function findWorkspace() {
 
     // 3. Relative path (Default installation structure: .../openclaw/skills/clawbridge)
     const relative = path.resolve(APP_DIR, '../../');
-    if (fs.existsSync(path.join(relative, 'memory'))) {
+    if (isWorkspaceLike(relative)) {
         workspaceCache = relative;
         return relative;
     }
 
     // 4. Common path probing (For standalone/sandbox installs)
+    // Prefer ~/.openclaw/workspace over ~/.openclaw to avoid selecting state dir by mistake.
     const candidates = [
+        path.join(HOME_DIR, '.openclaw', 'workspace'),
         path.join(HOME_DIR, 'clawd'), // Legacy clawdbot/clawd path
-        path.join(HOME_DIR, '.openclaw'), // Standard OpenClaw storage
+        path.join(HOME_DIR, '.openclaw'), // Standard OpenClaw storage/state root
         process.cwd(),
     ];
 
     for (const p of candidates) {
-        if (fs.existsSync(path.join(p, 'memory'))) {
+        if (isWorkspaceLike(p)) {
             console.log(`[Init] Probed workspace found: ${p}`);
             workspaceCache = p;
             return p;


### PR DESCRIPTION
## Summary
This fixes workspace auto-detection selecting the OpenClaw state root (`~/.openclaw`) instead of the real workspace (`~/.openclaw/workspace`) in some environments.

## What changed
- Added `isWorkspaceLike()` heuristic instead of only checking `memory/` existence.
- Added `hasReadableMemoryMarkdown()` to verify actual memory markdown files exist.
- Updated probe priority to prefer `~/.openclaw/workspace` before `~/.openclaw`.

## Why
When `~/.openclaw` is selected, Memory view can appear empty because daily markdown files live under `~/.openclaw/workspace/memory`.

## Validation
- Local check confirmed `WORKSPACE_DIR` resolves to `/Users/zhaijiayu/.openclaw/workspace` without setting `OPENCLAW_WORKSPACE`.
- Dashboard restart logs now consistently show the correct workspace path.
