### PR TITLE
fix: stop sending websocket auth key in URL

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -190,8 +190,9 @@ const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 const wsUrl = protocol + '//' + window.location.host;
 let ws;
 function connectWS() {
-    const wsAuthUrl = wsUrl + '?key=' + encodeURIComponent(API_KEY || '');
-    ws = new WebSocket(wsAuthUrl);
+    // Browser WebSocket connections automatically include the dashboard's
+    // session cookie, so avoid echoing the long-lived access key into the URL.
+    ws = new WebSocket(wsUrl);
     ws.onopen = () => console.log('WS Connected');
     ws.onclose = () => setTimeout(connectWS, 3000);
     ws.onmessage = (event) => {

--- a/tests/websocket.test.js
+++ b/tests/websocket.test.js
@@ -66,8 +66,10 @@ describe('WebSocket Authentication', () => {
         ws.on('error', done);
     });
 
-    test('correct x-claw-key in query string → connected (receives heartbeat)', done => {
-        const ws = new WebSocket(`ws://127.0.0.1:${port}?key=testkey123`);
+    test('correct x-claw-key header → connected (receives heartbeat)', done => {
+        const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+            headers: { 'x-claw-key': 'testkey123' },
+        });
         ws.on('message', (data) => {
             const msg = JSON.parse(data.toString());
             expect(msg).toHaveProperty('type', 'heartbeat');


### PR DESCRIPTION
## Summary
- stop appending the long-lived dashboard access key to the browser WebSocket URL
- rely on the existing session cookie for browser WebSocket auth instead
- update the WebSocket auth test to validate header-based programmatic access instead of query-string auth

## Validation
- `npx jest --runInBand --config jest.ws.config.cjs`

Fixes #29